### PR TITLE
fix: prevent clickApply being called twice

### DIFF
--- a/projects/ngx-daterangepicker-bootstrap/src/lib/components/daterangepicker/ngx-daterangepicker-bootstrap.component.ts
+++ b/projects/ngx-daterangepicker-bootstrap/src/lib/components/daterangepicker/ngx-daterangepicker-bootstrap.component.ts
@@ -948,9 +948,6 @@ export class NgxDaterangepickerBootstrapComponent implements OnInit, OnChanges {
       this.applyBtn.disabled = false;
       this.setEndDate(this.startDate);
       this.updateElement();
-      if (this.autoApply) {
-        this.clickApply();
-      }
     }
     this.updateView();
     if (this.autoApply && this.startDate && this.endDate) {


### PR DESCRIPTION
prevent clickApply being called twice when using `singleDatePicker` and `autoApply`.
` this.clickApply();` is acutally called a couple of line below the one I removed.